### PR TITLE
Configure ExoPlayer for automatic ducking

### DIFF
--- a/app/src/main/java/org/sunsetware/phocid/PlaybackService.kt
+++ b/app/src/main/java/org/sunsetware/phocid/PlaybackService.kt
@@ -39,13 +39,12 @@ class PlaybackService : MediaSessionService() {
     // Create your player and media session in the onCreate lifecycle event
     override fun onCreate() {
         super.onCreate()
-        val audioAttributes = AudioAttributes.Builder()
-            .setUsage(C.USAGE_MEDIA)
-            .setContentType(C.AUDIO_CONTENT_TYPE_MUSIC)
-            .build()
-        val player = ExoPlayer.Builder(this)
-            .setAudioAttributes(audioAttributes, true)
-            .build()
+        val audioAttributes =
+            AudioAttributes.Builder()
+                .setUsage(C.USAGE_MEDIA)
+                .setContentType(C.AUDIO_CONTENT_TYPE_MUSIC)
+                .build()
+        val player = ExoPlayer.Builder(this).setAudioAttributes(audioAttributes, true).build()
         player.addListener(
             object : Player.Listener {
                 override fun onEvents(player: Player, events: Player.Events) {

--- a/app/src/main/java/org/sunsetware/phocid/PlaybackService.kt
+++ b/app/src/main/java/org/sunsetware/phocid/PlaybackService.kt
@@ -5,6 +5,8 @@ import android.content.Intent
 import android.os.Bundle
 import android.os.SystemClock
 import androidx.annotation.OptIn
+import androidx.media3.common.AudioAttributes
+import androidx.media3.common.C
 import androidx.media3.common.Player
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.exoplayer.ExoPlayer
@@ -37,7 +39,13 @@ class PlaybackService : MediaSessionService() {
     // Create your player and media session in the onCreate lifecycle event
     override fun onCreate() {
         super.onCreate()
-        val player = ExoPlayer.Builder(this).build()
+        val audioAttributes = AudioAttributes.Builder()
+            .setUsage(C.USAGE_MEDIA)
+            .setContentType(C.AUDIO_CONTENT_TYPE_MUSIC)
+            .build()
+        val player = ExoPlayer.Builder(this)
+            .setAudioAttributes(audioAttributes, true)
+            .build()
         player.addListener(
             object : Player.Listener {
                 override fun onEvents(player: Player, events: Player.Events) {


### PR DESCRIPTION
Thank you for creating this app. :)

The audio focus docs[0] say that if you're using ExoPlayer, you should just let it handle ducking for you. Tested by taking a walk with Google Maps navigation running.

[0] https://developer.android.com/media/optimize/audio-focus