### PR TITLE
Import playlists recursively

### DIFF
--- a/app/src/main/java/org/sunsetware/phocid/data/Playlist.kt
+++ b/app/src/main/java/org/sunsetware/phocid/data/Playlist.kt
@@ -199,7 +199,10 @@ class PlaylistManager(
             syncLog.appendLine(Strings[R.string.playlist_io_sync_log_no_persistable_permission])
         }
 
-        val files = listSafFiles(context, uri, false)
+        val files =
+            listSafFiles(context, uri, false) {
+                it.name.endsWith(".m3u", true) || it.name.endsWith(".m3u8", true)
+            }
         if (files == null) {
             error = true
             syncLog.appendLine(Strings[R.string.playlist_io_sync_log_error_listing_files])
@@ -283,7 +286,12 @@ class PlaylistManager(
                         updatePlaylist(
                             key,
                             requireNotNull(
-                                listSafFiles(context, uri, false)?.get(file.name)?.lastModified
+                                listSafFiles(context, uri, false) {
+                                        it.name.endsWith(".m3u", true) ||
+                                            it.name.endsWith(".m3u8", true)
+                                    }
+                                    ?.get(file.relativePath)
+                                    ?.lastModified
                             ),
                             false,
                         ) {

--- a/app/src/main/java/org/sunsetware/phocid/data/Playlist.kt
+++ b/app/src/main/java/org/sunsetware/phocid/data/Playlist.kt
@@ -40,7 +40,14 @@ import org.apache.commons.io.FilenameUtils
 import org.sunsetware.phocid.PLAYLISTS_FILE_NAME
 import org.sunsetware.phocid.R
 import org.sunsetware.phocid.Strings
-import org.sunsetware.phocid.utils.*
+import org.sunsetware.phocid.utils.CaseInsensitiveMap
+import org.sunsetware.phocid.utils.UUIDSerializer
+import org.sunsetware.phocid.utils.combine
+import org.sunsetware.phocid.utils.decodeWithCharsetName
+import org.sunsetware.phocid.utils.icuFormat
+import org.sunsetware.phocid.utils.listSafFiles
+import org.sunsetware.phocid.utils.map
+import org.sunsetware.phocid.utils.trimAndNormalize
 
 enum class SpecialPlaylist(
     /** Version 8 UUID. Guaranteed to not collide with [UUID.randomUUID]. */
@@ -192,7 +199,7 @@ class PlaylistManager(
             syncLog.appendLine(Strings[R.string.playlist_io_sync_log_no_persistable_permission])
         }
 
-        val files = listSafFiles(context, uri)
+        val files = listSafFiles(context, uri, false)
         if (files == null) {
             error = true
             syncLog.appendLine(Strings[R.string.playlist_io_sync_log_error_listing_files])
@@ -276,7 +283,7 @@ class PlaylistManager(
                         updatePlaylist(
                             key,
                             requireNotNull(
-                                listSafFiles(context, uri)?.get(file.name)?.lastModified
+                                listSafFiles(context, uri, false)?.get(file.name)?.lastModified
                             ),
                             false,
                         ) {

--- a/app/src/main/java/org/sunsetware/phocid/ui/views/playlist/PlaylistIoScreen.kt
+++ b/app/src/main/java/org/sunsetware/phocid/ui/views/playlist/PlaylistIoScreen.kt
@@ -92,6 +92,7 @@ import org.sunsetware.phocid.ui.theme.Typography
 import org.sunsetware.phocid.utils.SafFile
 import org.sunsetware.phocid.utils.icuFormat
 import org.sunsetware.phocid.utils.listSafFiles
+import org.sunsetware.phocid.utils.listSafFilesRecursive
 import org.sunsetware.phocid.utils.trimAndNormalize
 
 @Stable
@@ -140,7 +141,7 @@ private constructor(tabType: PlaylistIoScreenTabType, initialExportSelection: Se
                 while (isActive) {
                     m3uFiles =
                         playlistIoDirectoryUri
-                            ?.let { listSafFiles(context, it) }
+                            ?.let { listSafFilesRecursive(context, it) }
                             ?.values
                             ?.filter {
                                 it.name.endsWith(".m3u", true) || it.name.endsWith(".m3u8", true)

--- a/app/src/main/java/org/sunsetware/phocid/ui/views/playlist/PlaylistIoScreen.kt
+++ b/app/src/main/java/org/sunsetware/phocid/ui/views/playlist/PlaylistIoScreen.kt
@@ -67,7 +67,6 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.media3.common.MimeTypes
 import com.ibm.icu.text.Collator
 import java.util.UUID
-import kotlin.collections.forEach
 import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
@@ -92,7 +91,6 @@ import org.sunsetware.phocid.ui.theme.Typography
 import org.sunsetware.phocid.utils.SafFile
 import org.sunsetware.phocid.utils.icuFormat
 import org.sunsetware.phocid.utils.listSafFiles
-import org.sunsetware.phocid.utils.listSafFilesRecursive
 import org.sunsetware.phocid.utils.trimAndNormalize
 
 @Stable
@@ -141,7 +139,7 @@ private constructor(tabType: PlaylistIoScreenTabType, initialExportSelection: Se
                 while (isActive) {
                     m3uFiles =
                         playlistIoDirectoryUri
-                            ?.let { listSafFilesRecursive(context, it) }
+                            ?.let { listSafFiles(context, it, true) }
                             ?.values
                             ?.filter {
                                 it.name.endsWith(".m3u", true) || it.name.endsWith(".m3u8", true)
@@ -566,7 +564,7 @@ private constructor(tabType: PlaylistIoScreenTabType, initialExportSelection: Se
                 while (isActive) {
                     files =
                         preferences.playlistIoSyncLocation?.let {
-                            listSafFiles(context, Uri.parse(it))
+                            listSafFiles(context, Uri.parse(it), false)
                         } ?: emptyMap()
                     delay(1.seconds)
                 }

--- a/app/src/main/java/org/sunsetware/phocid/ui/views/playlist/PlaylistIoScreen.kt
+++ b/app/src/main/java/org/sunsetware/phocid/ui/views/playlist/PlaylistIoScreen.kt
@@ -139,11 +139,14 @@ private constructor(tabType: PlaylistIoScreenTabType, initialExportSelection: Se
                 while (isActive) {
                     m3uFiles =
                         playlistIoDirectoryUri
-                            ?.let { listSafFiles(context, it, true) }
+                            ?.let {
+                                listSafFiles(context, it, true) {
+                                    it.name.endsWith(".m3u", true) ||
+                                        it.name.endsWith(".m3u8", true)
+                                }
+                            }
                             ?.values
-                            ?.filter {
-                                it.name.endsWith(".m3u", true) || it.name.endsWith(".m3u8", true)
-                            } ?: emptyList()
+                            ?.toList() ?: emptyList()
                     delay(1.seconds)
                 }
             }
@@ -425,7 +428,7 @@ private constructor(tabType: PlaylistIoScreenTabType, initialExportSelection: Se
                     LazyColumn(state = importLazyListState, modifier = Modifier.fillMaxSize()) {
                         items(m3uFiles, { it.uri }) { file ->
                             UtilityCheckBoxListItem(
-                                text = file.name,
+                                text = file.relativePath,
                                 checked = importSelection.contains(file.uri),
                                 onCheckedChange = {
                                     if (it) {
@@ -564,7 +567,9 @@ private constructor(tabType: PlaylistIoScreenTabType, initialExportSelection: Se
                 while (isActive) {
                     files =
                         preferences.playlistIoSyncLocation?.let {
-                            listSafFiles(context, Uri.parse(it), false)
+                            listSafFiles(context, Uri.parse(it), false) {
+                                it.name.endsWith(".m3u", true) || it.name.endsWith(".m3u8", true)
+                            }
                         } ?: emptyMap()
                     delay(1.seconds)
                 }

--- a/app/src/main/java/org/sunsetware/phocid/utils/SafFile.kt
+++ b/app/src/main/java/org/sunsetware/phocid/utils/SafFile.kt
@@ -10,14 +10,25 @@ import androidx.core.database.getLongOrNull
 @Immutable data class SafFile(val uri: Uri, val name: String, val lastModified: Long?)
 
 fun listSafFiles(context: Context, uri: Uri): Map<String, SafFile>? {
+    return listSafFilesGeneric(context, uri, false)
+}
+
+fun listSafFilesRecursive(context: Context, uri: Uri): Map<String, SafFile>? {
+    return listSafFilesGeneric(context, uri, true)
+}
+
+private fun listSafFilesGeneric(context: Context, uri: Uri, recursive: Boolean): Map<String, SafFile>? {
+    val resolver = context.contentResolver
     val treeUri =
         DocumentsContract.buildDocumentUriUsingTree(uri, DocumentsContract.getTreeDocumentId(uri))
-
-    val resolver = context.contentResolver
+    val docUri =
+        if (DocumentsContract.isDocumentUri(context, uri)) {
+            DocumentsContract.buildDocumentUriUsingTree(uri, DocumentsContract.getDocumentId(uri))
+        } else treeUri
     val childrenUri =
         DocumentsContract.buildChildDocumentsUriUsingTree(
             treeUri,
-            DocumentsContract.getDocumentId(treeUri),
+            DocumentsContract.getDocumentId(docUri),
         )
     val results = mutableMapOf<String, SafFile>()
 
@@ -40,14 +51,19 @@ fun listSafFiles(context: Context, uri: Uri): Map<String, SafFile>? {
             .use { cursor ->
                 while (cursor.moveToNext()) {
                     val mimeType = cursor.getString(0)
-                    if (mimeType == DocumentsContract.Document.MIME_TYPE_DIR) continue
-
                     val documentId = cursor.getString(1)
                     val documentUri =
                         DocumentsContract.buildDocumentUriUsingTree(treeUri, documentId)
-                    val name = cursor.getString(2)
-                    val lastModified = cursor.getLongOrNull(3)
-                    results[name] = SafFile(documentUri, name, lastModified)
+
+                    if (mimeType == DocumentsContract.Document.MIME_TYPE_DIR) {
+                        if (recursive) {
+                            listSafFilesGeneric(context, documentUri, true)?.let {results.putAll(it)}
+                        }
+                    } else {
+                        val name = cursor.getString(2)
+                        val lastModified = cursor.getLongOrNull(3)
+                        results[name] = SafFile(documentUri, name, lastModified)
+                    }
                 }
             }
     } catch (ex: Exception) {


### PR DESCRIPTION
**Summary** 
This pull request enhances the import functionality to include m3u playlist files from subdirectories.

**Current Behavior**
    When selecting a directory, only the m3u files in that directory are available for import. For example, in the following directory structure:

```
parentDir
│
├── playlist1.m3u
│
└── subDir
    │
    └── playlist2.m3u
```

Only playlist1.m3u would appear when selecting parentDir.

**Proposed Changes**

This pull request addresses this limitation by recursively calling listSafFiles for all subdirectories.
To avoid interfering with the existing sync feature, I created two new functions. The original function remains unchanged for sync operations. A new function, listSafFilesRecursive, is introduced for importing m3u files from both the selected directory and its subdirectories.
